### PR TITLE
add prettierrc

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,5 @@
+{
+  "trailingComma": "all",
+  "semi": false,
+  "singleQuote": true
+}


### PR DESCRIPTION
Mirrors the rules outlined in .eslintrc.js. Helps for users that have a Prettier extension on their editor that may not match the rules in .eslintrc.js